### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/django_google_storage/format.py
+++ b/django_google_storage/format.py
@@ -28,7 +28,7 @@ class _CallingFormat(object):
         return ''
 
     def build_url_base(self, connection, protocol, server, bucket, key=''):
-        url_base = '%s://' % protocol
+        url_base = '{0!s}://'.format(protocol)
         url_base += self.build_host(server, bucket)
         url_base += connection.get_path(self.build_path_base(bucket, key))
         return url_base
@@ -44,14 +44,14 @@ class _CallingFormat(object):
         path = ''
         if bucket != '':
             path = '/' + bucket
-        return path + '/%s' % urllib.quote(key)
+        return path + '/{0!s}'.format(urllib.quote(key))
 
     def build_path_base(self, bucket, key=''):
         key = boto.utils.get_utf8_value(key)
-        return '/%s' % urllib.quote(key)
+        return '/{0!s}'.format(urllib.quote(key))
 
 
 class SubdomainCallingFormat(_CallingFormat):
     @assert_case_insensitive
     def get_bucket_server(self, server, bucket):
-        return '%s.%s' % (bucket, server)
+        return '{0!s}.{1!s}'.format(bucket, server)

--- a/django_google_storage/storage.py
+++ b/django_google_storage/storage.py
@@ -113,7 +113,7 @@ class GoogleStorage(Storage):
                 bucket = self.connection.create_bucket(name)
                 bucket.set_acl(self.bucket_acl)
                 return bucket
-            raise ImproperlyConfigured("%s" % str(e))
+            raise ImproperlyConfigured("{0!s}".format(str(e)))
 
     def _clean_name(self, name):
         # Useful for windows' paths
@@ -123,7 +123,7 @@ class GoogleStorage(Storage):
         try:
             return safe_join(self.location, name).lstrip('/')
         except ValueError:
-            raise SuspiciousOperation("Attempted access to '%s' denied." % name)
+            raise SuspiciousOperation("Attempted access to '{0!s}' denied.".format(name))
 
     def _encode_name(self, name):
         return smart_str(name, encoding=self.file_name_charset)
@@ -135,7 +135,7 @@ class GoogleStorage(Storage):
         name = self._normalize_name(self._clean_name(name))
         f = GSBotoStorageFile(name, mode, self)
         if not f.key:
-            raise IOError('File does not exist: %s' % name)
+            raise IOError('File does not exist: {0!s}'.format(name))
         return f
 
     def _save(self, name, content):
@@ -213,7 +213,7 @@ class GoogleStorage(Storage):
     def url(self, name):
         name = self._normalize_name(self._clean_name(name))
         if self.custom_domain:
-            return "%s://%s/%s" % ('https' if self.secure_urls else 'http', self.custom_domain, name)
+            return "{0!s}://{1!s}/{2!s}".format('https' if self.secure_urls else 'http', self.custom_domain, name)
         else:
             return self.connection.generate_url(self.querystring_expire, method='GET', \
                                                 bucket=self.bucket.name, key=self._encode_name(name),


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:budurli:django-google-storage?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:budurli:django-google-storage?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)